### PR TITLE
Add support for static methods

### DIFF
--- a/lib/html4-entities.js
+++ b/lib/html4-entities.js
@@ -48,6 +48,14 @@ Html4Entities.prototype.decode = function(str) {
  * @param {String} str
  * @returns {String}
  */
+Html4Entities.decode = function(str) {
+    return new Html4Entities().decode(str);
+};
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
 Html4Entities.prototype.encode = function(str) {
     var strLength = str.length;
     if (strLength === 0) {
@@ -61,6 +69,14 @@ Html4Entities.prototype.encode = function(str) {
         i++;
     }
     return result;
+};
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
+Html4Entities.encode = function(str) {
+    return new Html4Entities().encode(str);
 };
 
 /**
@@ -93,6 +109,14 @@ Html4Entities.prototype.encodeNonUTF = function(str) {
  * @param {String} str
  * @returns {String}
  */
+Html4Entities.encodeNonUTF = function(str) {
+    return new Html4Entities().encodeNonUTF(str);
+};
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
 Html4Entities.prototype.encodeNonASCII = function(str) {
     var strLength = str.length;
     if (strLength === 0) {
@@ -110,6 +134,14 @@ Html4Entities.prototype.encodeNonASCII = function(str) {
         i++;
     }
     return result;
+};
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
+Html4Entities.encodeNonASCII = function(str) {
+    return new Html4Entities().encodeNonASCII(str);
 };
 
 module.exports = Html4Entities;

--- a/lib/html5-entities.js
+++ b/lib/html5-entities.js
@@ -39,6 +39,14 @@ Html5Entities.prototype.decode = function(str) {
  * @param {String} str
  * @returns {String}
  */
+ Html5Entities.decode = function(str) {
+    return new Html5Entities().decode(str);
+ };
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
 Html5Entities.prototype.encode = function(str) {
     var strLength = str.length;
     if (strLength === 0) {
@@ -66,6 +74,14 @@ Html5Entities.prototype.encode = function(str) {
     }
     return result;
 };
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
+ Html5Entities.encode = function(str) {
+    return new Html5Entities().encode(str);
+ };
 
 /**
  * @param {String} str
@@ -108,6 +124,14 @@ Html5Entities.prototype.encodeNonUTF = function(str) {
  * @param {String} str
  * @returns {String}
  */
+ Html5Entities.encodeNonUTF = function(str) {
+    return new Html5Entities().encodeNonUTF(str);
+ };
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
 Html5Entities.prototype.encodeNonASCII = function(str) {
     var strLength = str.length;
     if (strLength === 0) {
@@ -126,6 +150,14 @@ Html5Entities.prototype.encodeNonASCII = function(str) {
     }
     return result;
 };
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
+ Html5Entities.encodeNonASCII = function(str) {
+    return new Html5Entities().encodeNonASCII(str);
+ };
 
 /**
  * @param {Object} alphaIndex Passed by reference.

--- a/lib/xml-entities.js
+++ b/lib/xml-entities.js
@@ -49,6 +49,14 @@ XmlEntities.prototype.encode = function(str) {
  * @param {String} str
  * @returns {String}
  */
+ XmlEntities.encode = function(str) {
+    return new XmlEntities().encode(str);
+ };
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
 XmlEntities.prototype.decode = function(str) {
     if (str.length === 0) {
         return '';
@@ -67,6 +75,14 @@ XmlEntities.prototype.decode = function(str) {
         return ALPHA_INDEX[s] || s;
     });
 };
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
+ XmlEntities.decode = function(str) {
+    return new XmlEntities().decode(str);
+ };
 
 /**
  * @param {String} str
@@ -101,6 +117,14 @@ XmlEntities.prototype.encodeNonUTF = function(str) {
  * @param {String} str
  * @returns {String}
  */
+ XmlEntities.encodeNonUTF = function(str) {
+    return new XmlEntities().encodeNonUTF(str);
+ };
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
 XmlEntities.prototype.encodeNonASCII = function(str) {
     var strLenght = str.length;
     if (strLenght === 0) {
@@ -119,5 +143,13 @@ XmlEntities.prototype.encodeNonASCII = function(str) {
     }
     return result;
 };
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
+ XmlEntities.encodeNonASCII = function(str) {
+    return new XmlEntities().encodeNonASCII(str);
+ };
 
 module.exports = XmlEntities;

--- a/test/html4-entities.test.js
+++ b/test/html4-entities.test.js
@@ -11,11 +11,24 @@ describe('html4 entities', function () {
         html4Entities.encodeNonUTF('<>"&©∆').should.equal('&lt;&gt;&quot;&amp;&copy;&#8710;');
         html4Entities.encodeNonASCII('').should.equal('');
         html4Entities.encodeNonASCII('<>"&©®∆').should.equal('<>"&©®&#8710;');
+
+        htmlEntities.Html4Entities.encode('').should.equal('');
+        htmlEntities.Html4Entities.encode('<>"&').should.equal('&lt;&gt;&quot;&amp;');
+        htmlEntities.Html4Entities.encode('<>"&©').should.equal('&lt;&gt;&quot;&amp;&copy;');
+        htmlEntities.Html4Entities.encodeNonUTF('').should.equal('');
+        htmlEntities.Html4Entities.encodeNonUTF('<>"&©∆').should.equal('&lt;&gt;&quot;&amp;&copy;&#8710;');
+        htmlEntities.Html4Entities.encodeNonASCII('').should.equal('');
+        htmlEntities.Html4Entities.encodeNonASCII('<>"&©®∆').should.equal('<>"&©®&#8710;');
     });
     it('should decode html4 entities', function () {
         html4Entities.decode('').should.equal('');
         html4Entities.decode('&lt;&gt;&quot;&amp;').should.equal('<>"&');
         html4Entities.decode('&lt;&gt;&quot;&amp;&acE;&copy;').should.equal('<>"&&acE;©');
         html4Entities.decode('&#60;&#x3C;').should.equal('<<');
+
+        htmlEntities.Html4Entities.decode('').should.equal('');
+        htmlEntities.Html4Entities.decode('&lt;&gt;&quot;&amp;').should.equal('<>"&');
+        htmlEntities.Html4Entities.decode('&lt;&gt;&quot;&amp;&acE;&copy;').should.equal('<>"&&acE;©');
+        htmlEntities.Html4Entities.decode('&#60;&#x3C;').should.equal('<<');
     });
 });

--- a/test/html5-entities.test.js
+++ b/test/html5-entities.test.js
@@ -12,6 +12,15 @@ describe('html5 entities', function () {
         html5Entities.encodeNonUTF('<>"&©∆').should.equal('&lt;&gt;&quot;&amp;&copy;&#8710;');
         html5Entities.encodeNonASCII('').should.equal('');
         html5Entities.encodeNonASCII('<>"&©®∆').should.equal('<>"&©®&#8710;');
+
+        htmlEntities.Html5Entities.encode('').should.equal('');
+        htmlEntities.Html5Entities.encode('<>"&').should.equal('&lt;&gt;&quot;&amp;');
+        htmlEntities.Html5Entities.encode('<>"&©').should.equal('&lt;&gt;&quot;&amp;&copy;');
+        htmlEntities.Html5Entities.encode('∾̳').should.equal('&acE;');
+        htmlEntities.Html5Entities.encodeNonUTF('').should.equal('');
+        htmlEntities.Html5Entities.encodeNonUTF('<>"&©∆').should.equal('&lt;&gt;&quot;&amp;&copy;&#8710;');
+        htmlEntities.Html5Entities.encodeNonASCII('').should.equal('');
+        htmlEntities.Html5Entities.encodeNonASCII('<>"&©®∆').should.equal('<>"&©®&#8710;');
     });
     it('should decode html5 entities', function () {
         html5Entities.decode('').should.equal('');
@@ -23,5 +32,15 @@ describe('html5 entities', function () {
         html5Entities.decode('&#60;&#x3C;&Aacute;&asdasd;').should.equal('<<Á&asdasd;');
         html5Entities.decode('&acE;').should.equal('∾̳');
         html5Entities.decode('&acE;x').should.equal('∾̳x');
+
+        htmlEntities.Html5Entities.decode('').should.equal('');
+        htmlEntities.Html5Entities.decode('&Lt;&gt;&quot;&amp;').should.equal('≪>"&');
+        htmlEntities.Html5Entities.decode('&lt;&gt;&quot;&amp;').should.equal('<>"&');
+        htmlEntities.Html5Entities.decode('&LT;&GT;&QUOT;&AMP;').should.equal('<>"&');
+        htmlEntities.Html5Entities.decode('&lt;&gt;&quot;&amp;©').should.equal('<>"&©');
+        htmlEntities.Html5Entities.decode('&lt;&gt;&quot;&amp;&copy;').should.equal('<>"&©');
+        htmlEntities.Html5Entities.decode('&#60;&#x3C;&Aacute;&asdasd;').should.equal('<<Á&asdasd;');
+        htmlEntities.Html5Entities.decode('&acE;').should.equal('∾̳');
+        htmlEntities.Html5Entities.decode('&acE;x').should.equal('∾̳x');
     });
 });

--- a/test/xml-entities.test.js
+++ b/test/xml-entities.test.js
@@ -11,6 +11,14 @@ describe('xml entities', function () {
         xmlEntities.encodeNonUTF('<>"&©®').should.equal('&lt;&gt;&quot;&amp;&#169;&#174;');
         xmlEntities.encodeNonASCII('').should.equal('');
         xmlEntities.encodeNonASCII('<>"&©®').should.equal('<>"&©®');
+
+        htmlEntities.XmlEntities.encode('').should.equal('');
+        htmlEntities.XmlEntities.encode('<>"&\'').should.equal('&lt;&gt;&quot;&amp;&apos;');
+        htmlEntities.XmlEntities.encode('<>"&©').should.equal('&lt;&gt;&quot;&amp;©');
+        htmlEntities.XmlEntities.encodeNonUTF('').should.equal('');
+        htmlEntities.XmlEntities.encodeNonUTF('<>"&©®').should.equal('&lt;&gt;&quot;&amp;&#169;&#174;');
+        htmlEntities.XmlEntities.encodeNonASCII('').should.equal('');
+        htmlEntities.XmlEntities.encodeNonASCII('<>"&©®').should.equal('<>"&©®');
     });
     it('should decode xml entities', function () {
         xmlEntities.decode('').should.equal('');
@@ -18,5 +26,11 @@ describe('xml entities', function () {
         xmlEntities.decode('&lt;&gt;&quot;&amp;©').should.equal('<>"&©');
         xmlEntities.decode('&lt;&gt;&quot;&amp;©').should.equal('<>"&©');
         xmlEntities.decode('&lt;&gt;&quot;&amp;&copy;&#8710;').should.equal('<>"&&copy;∆');
+
+        htmlEntities.XmlEntities.decode('').should.equal('');
+        htmlEntities.XmlEntities.decode('&lt;&gt;&quot;&amp;&apos;').should.equal('<>"&\'');
+        htmlEntities.XmlEntities.decode('&lt;&gt;&quot;&amp;©').should.equal('<>"&©');
+        htmlEntities.XmlEntities.decode('&lt;&gt;&quot;&amp;©').should.equal('<>"&©');
+        htmlEntities.XmlEntities.decode('&lt;&gt;&quot;&amp;&copy;&#8710;').should.equal('<>"&&copy;∆');
     });
 });


### PR DESCRIPTION
The pull adds static methods to the the html4/5/xml entities objects.

It is unnecessary to instantiate a new `XmlEntities` object, for example, because there's no state maintained within that object.  Instead, all of the methods can be static, which removes the need to create a `new XmlEntities()`, and instead allows for `XmlEntities.encode`, `Html4Entities.decode`, etc.