### PR TITLE
Fixed missing var statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ console.log(entities.decode('&lt;&gt;&quot;&apos;&amp;&copy;&reg;&#8710;')); // 
 ```javascript
 var Entities = require('html-entities').AllHtmlEntities;
 
-entities = new Entities();
+var entities = new Entities();
 
 console.log(entities.encode('<>"&©®∆')); // &lt;&gt;&quot;&amp;&copy;&reg;∆
 console.log(entities.encodeNonUTF('<>"&©®∆')); // &lt;&gt;&quot;&amp;&copy;&reg;&#8710;


### PR DESCRIPTION
The documentation shows the declaration of a variable without 'var' statement which would unintentionally create a global.
Since docs are copy/pasted quite often, this should be fixed.