### PR TITLE
Change README title node-html-entities -> html-entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-node-html-entities
+html-entities
 ==================
 
 [![Build Status](https://travis-ci.org/mdevils/node-html-entities.svg?branch=master)](https://travis-ci.org/mdevils/node-html-entities)


### PR DESCRIPTION
Sometimes...I don't read on the internet. 😥  So, when I saw the title of this README was node-html-entities, I ran `npm i node-html-entities`, which does not exist and is the wrong package name. 

So, just proposing updating the title to match the name of the actual package. 😄 	